### PR TITLE
Small fix for Embed Messages

### DIFF
--- a/actions/send_embed_message.js
+++ b/actions/send_embed_message.js
@@ -68,7 +68,7 @@ variableStorage: function(data, varType) {
 // are also the names of the fields stored in the action's JSON data.
 //---------------------------------------------------------------------
 
-fields: ["storage", "varName", "channel", "varName2", "storage3", "varName3"],
+fields: ["storage", "varName", "channel", "varName2", "storage3", "varName3", "iffalse", "iffalseVal"],
 
 //---------------------------------------------------------------------
 // Command HTML


### PR DESCRIPTION
Fixed the "If Message Delivery Fails" field. Now saves when you press "Edit Action".