### PR TITLE
Fix depreciation warning

### DIFF
--- a/actions/create_channel.js
+++ b/actions/create_channel.js
@@ -125,7 +125,7 @@ action: function(cache) {
 		const name = this.evalMessage(data.channelName, cache);
 		const catid = this.evalMessage(data.categoryID, cache);
 		const storage = parseInt(data.storage);
-		server.createChannel(name, 'text').then(function(channel) {
+		server.createChannel('name', {type: 'text'}).then(function(channel) {
 			const channelData = {};
 			if(data.position) {
 				channelData.position = parseInt(data.position);

--- a/actions/create_channel.js
+++ b/actions/create_channel.js
@@ -124,19 +124,10 @@ action: function(cache) {
 	if(server && server.createChannel) {
 		const name = this.evalMessage(data.channelName, cache);
 		const catid = this.evalMessage(data.categoryID, cache);
+		const topic = this.evalMessage(data.topic, cache);
+		const position = parseInt(data.position);
 		const storage = parseInt(data.storage);
-		server.createChannel(name, {type: 'text'}).then(function(channel) {
-			const channelData = {};
-			if(data.position) {
-				channelData.position = parseInt(data.position);
-			}
-			if(data.topic) {
-				channelData.topic = this.evalMessage(data.topic, cache);
-			}
-			channel.edit(channelData);
-			if(catid) {
-				channel.setParent(catid);
-			}
+		server.createChannel(name, {type: 'text', topic: topic, position: position, parent: catid}).then(function(channel) {
 			const varName = this.evalMessage(data.varName, cache);
 			this.storeValue(channel, storage, varName, cache);
 			this.callNextAction(cache);

--- a/actions/create_channel.js
+++ b/actions/create_channel.js
@@ -125,7 +125,7 @@ action: function(cache) {
 		const name = this.evalMessage(data.channelName, cache);
 		const catid = this.evalMessage(data.categoryID, cache);
 		const storage = parseInt(data.storage);
-		server.createChannel('name', {type: 'text'}).then(function(channel) {
+		server.createChannel(name, {type: 'text'}).then(function(channel) {
 			const channelData = {};
 			if(data.position) {
 				channelData.position = parseInt(data.position);


### PR DESCRIPTION
changed: `server.createChannel(name, 'text')` to `server.createChannel('name',{type: 'text'}`