### PR TITLE
Almeida: Fix channel category name from breaking

### DIFF
--- a/actions/store_channel_info.js
+++ b/actions/store_channel_info.js
@@ -228,7 +228,7 @@ action: function(cache) {
 			result = targetChannel.createdAt;
 			break;
 		case 10:
-			result = targetChannel.parent.name;
+			result = targetChannel.parent && targetChannel.parent.name;
 			break;
 		default:
 			break;


### PR DESCRIPTION
fix from Almeida to make channel category name not break if the channel has no category